### PR TITLE
Update frmFileSync.frm of MDINotepad Example

### DIFF
--- a/Examples/MDINotepad/frmFileSync.frm
+++ b/Examples/MDINotepad/frmFileSync.frm
@@ -6,6 +6,7 @@
 			#cmdline "FileSync.rc"
 		#endif
 	#endif
+	#include once "mff/Form.bi"
 	#include once "mff/TextBox.bi"
 	#include once "mff/CommandButton.bi"
 	#include once "mff/Panel.bi"
@@ -20,7 +21,6 @@
 	#include once "mff/Chart.bi"
 	#include once "mff/GroupBox.bi"
 	#include once "mff/Dialogs.bi"
-	#include once "mff/Form.bi"
 	
 	#include once "ITL3.bi"
 	#include once "TimeMeter.bi"


### PR DESCRIPTION
Resolve FileSync project compile error

```
10:06:54: FreeBASIC Compiler - Version 1.10.0 (2022-06-24), built for win64 (64bit)
10:06:54: Copyright (C) 2004-2022 The FreeBASIC development team.
10:06:54: standalone 
10:06:54: target :       win64, x86-64, 64bit
10:06:54: backend :      gcc
10:06:54: compiling :    frmFileSync.frm -o frmFileSync.c (main module)
frmFileSync.frm(6) warning 46(1): #cmdline ignored
F:\OfficePC_Update\!FB\!VisualFBEditor\VisualFBEditor-master\Controls\MyFbFramework\mff\Form.bas(208) error 42: Variable not declared, pApp
F:\OfficePC_Update\!FB\!VisualFBEditor\VisualFBEditor-master\Controls\MyFbFramework\mff\Form.bas(208) error 3: Expected End-of-Line, found 'pApp'
F:\OfficePC_Update\!FB\!VisualFBEditor\VisualFBEditor-master\Controls\MyFbFramework\mff\Form.bas(209) error 9: Expected expression, found 'pApp'
F:\OfficePC_Update\!FB\!VisualFBEditor\VisualFBEditor-master\Controls\MyFbFramework\mff\Form.bas(209) error 3: Expected End-of-Line, found 'pApp'
F:\OfficePC_Update\!FB\!VisualFBEditor\VisualFBEditor-master\Controls\MyFbFramework\mff\Form.bas(216) error 3: Expected End-of-Line, found 'pApp'
F:\OfficePC_Update\!FB\!VisualFBEditor\VisualFBEditor-master\Controls\MyFbFramework\mff\Form.bas(218) error 3: Expected End-of-Line, found 'pApp'
F:\OfficePC_Update\!FB\!VisualFBEditor\VisualFBEditor-master\Controls\MyFbFramework\mff\Form.bas(221) error 130: Expected 'END PROPERTY', found 'End'
F:\OfficePC_Update\!FB\!VisualFBEditor\VisualFBEditor-master\Controls\MyFbFramework\mff\Form.bas(1259) error 9: Expected expression, found 'pApp'
F:\OfficePC_Update\!FB\!VisualFBEditor\VisualFBEditor-master\Controls\MyFbFramework\mff\Form.bas(1259) error 3: Expected End-of-Line, found 'pApp'
F:\OfficePC_Update\!FB\!VisualFBEditor\VisualFBEditor-master\Controls\MyFbFramework\mff\Form.bas(1260) error 3: Expected End-of-Line, found 'pApp'
F:\OfficePC_Update\!FB\!VisualFBEditor\VisualFBEditor-master\Controls\MyFbFramework\mff\Form.bas(1260) error 133: Too many errors, exiting
```