### PR TITLE
Revert "Merge pull request #819 from hustbeef/master"

### DIFF
--- a/src/Main.bas
+++ b/src/Main.bas
@@ -11241,7 +11241,6 @@ Sub frmMain_Resize(ByRef Designer As My.Sys.Object, ByRef sender As My.Sys.Objec
 		stBar.Panels[0]->Width = Max(stBar.Width - 50 - stBar.Panels[1]->Width - stBar.Panels[2]->Width - stBar.Panels[3]->Width  - stBar.Panels[4]->Width - stBar.Panels[5]->Width, 20)
 		prProgress.Left = stBar.Panels[0]->Width + stBar.Panels[1]->Width 
 	#endif
-	frmMain.RequestAlign(NewWidth, NewHeight, False)
 End Sub
 
 Sub frmMain_KeyDown(ByRef Designer As My.Sys.Object, ByRef sender As My.Sys.Object, Key As Integer, Shift As Integer)


### PR DESCRIPTION
This reverts commit 8ec589e0d5248af38ddbe4cddeedc58011d98938, reversing changes made to 9ebfcf71e95d4b82e0f29b51340960411378a2b4. 
Rebar resize after frmMain resize, but the status bar and right tab panel also disappear. 