### PR TITLE
Fixed: GDB debug fails for filenames containing spaces.

### DIFF
--- a/src/Debug.bas
+++ b/src/Debug.bas
@@ -6545,7 +6545,7 @@ Private Function var_search(pproc As Integer,text() As String,vnb As Integer,var
 						
 					End If
 					tvar += 1 'next element, a component
-				ElseIf vrb(vrr(begv).vr).nm = "THIS" Then
+				ElseIf Ucase(vrb(vrr(begv).vr).nm) = "THIS" Then
 					Dim ivrr As Integer = var_search2(text(tvar), vrb(vrr(begv).vr).typ, procr(pproc).tv)
 					If ivrr <> -1 Then Return ivrr
 				End If
@@ -14299,7 +14299,7 @@ End Sub
 		
 	End Function
 	
-	Function load_file(ByRef sCurentFileExe As UString, ByRef sPathGDB As UString) As Long
+	Function load_file(ByRef sCurentFileExe As WString, ByRef sPathGDB As WString) As Long
 		
 		#ifdef __USE_GTK__
 			If g_find_program_in_path(ToUtf8(sPathGDB)) = NULL Then
@@ -14341,7 +14341,7 @@ End Sub
 		
 		'Updateinfoxserver(10)
 		
-		iGlPid = CreatePipeD(sPathGDB,  "-f" , sCurentFileExe )
+		iGlPid = CreatePipeD(sPathGDB,  "-f" , Chr(34) & sCurentFileExe & Chr(34))
 		
 		'Updateinfoxserver(150)
 		

--- a/src/Main.bas
+++ b/src/Main.bas
@@ -1497,21 +1497,30 @@ End Function
 
 Sub ClearTreeNode(ByRef tn As TreeNode Ptr)
 	If tn = 0 Then Exit Sub
-	Dim As TabWindow Ptr tb
-	For i As Integer = 0 To tn->Nodes.Count - 1
-		ClearTreeNode(tn->Nodes.Item(i))
-		For jj As Integer = 0 To TabPanels.Count - 1
-			Var ptabCode = @Cast(TabPanel Ptr, TabPanels.Item(jj))->tabCode
-			For j As Integer = 0 To ptabCode->TabCount - 1
-				tb = Cast(TabWindow Ptr, ptabCode->Tab(j))
-				If tb->tn = tn->Nodes.Item(i) Then
-					tb->tn = 0
-					Exit For
-				End If
-			Next j
-		Next jj
-		If tn->Nodes.Item(i)->Tag <> 0 Then _Delete( Cast(ExplorerElement Ptr, tn->Nodes.Item(i)->Tag)): tn->Nodes.Item(i)->Tag = 0
-	Next
+    Dim As TabWindow Ptr tb
+    Dim As TreeNode Ptr childNode
+    Dim As ExplorerElement Ptr elemPtr
+    For i As Integer = tn->Nodes.Count - 1 To 0 Step -1
+        childNode = tn->Nodes.Item(i)
+        If childNode = 0 Then Continue For
+        ClearTreeNode(childNode)
+        For jj As Integer = 0 To TabPanels.Count - 1
+            Var ptabCode = @Cast(TabPanel Ptr, TabPanels.Item(jj))->tabCode
+            For j As Integer = 0 To ptabCode->TabCount - 1
+                tb = Cast(TabWindow Ptr, ptabCode->Tab(j))
+                If tb->tn = childNode Then
+                    tb->tn = 0
+                    Exit For
+                End If
+            Next j
+        Next jj
+        If childNode->Tag <> 0 Then
+            elemPtr = Cast(ExplorerElement Ptr, childNode->Tag)
+            childNode->Tag = 0 
+            If elemPtr = 0 Then Continue For
+            _Delete(elemPtr)
+        End If
+    Next i
 	tn->Nodes.Clear
 End Sub
 


### PR DESCRIPTION
Fix the crash occurring when refreshing the tree node after a "save as" operation in Tabwindows.
when calling _Delete inside the 'If tb->tn = tn->Nodes.Item(i) Then' statement.